### PR TITLE
Kmt 134 verify user on licence switch

### DIFF
--- a/lib/helpers/cookieHandler.js
+++ b/lib/helpers/cookieHandler.js
@@ -1,0 +1,23 @@
+const Cookies = require('cookies');
+const config = require('../config');
+const logger = require('../logger');
+
+function decode(string) {
+  var body = new Buffer(string, 'base64').toString('utf8');
+  return JSON.parse(body);
+}
+
+//TODO make this less brittle and configurable
+module.exports = {
+  getKmtCookie: function(req, res) {
+    const cookieHandler = new Cookies(req, res, {keys:[config.get('KMT_SECRET')]});
+    const getKmtCookie = cookieHandler.get('FTkmt', {signed:true});
+    if (getKmtCookie) {
+        logger.info({operation: 'getKmtCookie', result: 'getKmtCookie cookie exists', cookieValue:getKmtCookie});
+        return decode(getKmtCookie);
+    }
+
+    logger.info({operation:'getKmtCookie', result:'getKmtCookie cookie does not exist'});
+    return;
+  }
+};

--- a/lib/helpers/cookieHandler.js
+++ b/lib/helpers/cookieHandler.js
@@ -3,7 +3,7 @@ const config = require('../config');
 const logger = require('../logger');
 
 function decode(string) {
-  var body = new Buffer(string, 'base64').toString('utf8');
+  const body = new Buffer(string, 'base64').toString('utf8');
   return JSON.parse(body);
 }
 

--- a/lib/middleware/isAdminSession.js
+++ b/lib/middleware/isAdminSession.js
@@ -2,6 +2,8 @@ const logger = require('../logger');
 const licenceListSort = require('../licenceListSort');
 const accessLicenceService = require('../services/accessLicenceService');
 const licenceDataService = require('../services/licenceDataService');
+const cookieHandler = require('../helpers/cookieHandler');
+
 
 function* licenceDetails(licenceId, adminUserId) {
   const responses = yield [
@@ -36,6 +38,7 @@ function* isAdminUser(req, res, next) {
       //Does a KMT session exist
       if (req.session.isPopulated) {
           logger.info({operation:'hasKMTSession', kmtSessionExists: 'true'});
+          logger.info({operation:'getKMTSessionValue', kmtSession:JSON.stringify(cookieHandler.getKmtCookie(req,res))});
           next();
 
       } else if (req.currentUser.uuid) {

--- a/lib/middleware/isAdminSession.js
+++ b/lib/middleware/isAdminSession.js
@@ -2,7 +2,7 @@ const logger = require('../logger');
 const licenceListSort = require('../licenceListSort');
 const accessLicenceService = require('../services/accessLicenceService');
 const licenceDataService = require('../services/licenceDataService');
-const cookieHandler = require('../helpers/cookieHandler');
+//const cookieHandler = require('../helpers/cookieHandler');
 
 
 function* licenceDetails(licenceId, adminUserId) {
@@ -13,6 +13,16 @@ function* licenceDetails(licenceId, adminUserId) {
 
   ];
   return responses;
+}
+
+function isLicenceInList(currentLicencelist, activeLicence) {
+  if (currentLicencelist.some(licence => licence.licenceId === activeLicence)) {
+      logger.info({operation:'isLicenceInList', activeLicence:activeLicence ,IsInList: 'true'});
+    return true;
+  }
+
+  logger.info({operation:'isLicenceInList', activeLicence:activeLicence ,IsInList: 'false'});
+
 }
 
 function* getAdminUserList(req, res, next) {
@@ -35,10 +45,11 @@ function* isAdminUser(req, res, next) {
   logger.info({operation:'isAdminUser', licence: req.licenceId});
 
     try {
-      //Does a KMT session exist
-      if (req.session.isPopulated) {
+      //Does KMT sessions exist
+      //Todo should we check for FTSession here too?
+      if (req.session.isPopulated && isLicenceInList(req.session.kmtLoggedIn.licenceList, req.licenceId)) {
           logger.info({operation:'hasKMTSession', kmtSessionExists: 'true'});
-          logger.info({operation:'getKMTSessionValue', kmtSession:JSON.stringify(cookieHandler.getKmtCookie(req,res))});
+          logger.info({operation:'isAdminUser', licenceExistsInSession:true});
           next();
 
       } else if (req.currentUser.uuid) {
@@ -54,7 +65,7 @@ function* isAdminUser(req, res, next) {
 
         if (!adminUserList.some(user => user.id === currentUser)) {
             //Not an admin user.
-            const err = new Error('Current user is not an admin user');
+            const err = new Error('Current user is not an admin user on this licence');
             err.status = 403;
             throw err;
         }

--- a/lib/middleware/verifySession.js
+++ b/lib/middleware/verifySession.js
@@ -16,7 +16,6 @@ function getSessionCookie(req, res) {
 }
 
 function* getUserId(req, res, next) {
-    //const loginRedirect = uriConstructor.redirectUrl(req.originalUrl);
     const FTsessionToken = getSessionCookie(req, res);
     logger.info({operation: 'getUseId', licenceId: req.licenceId});
       if (FTsessionToken) {


### PR DESCRIPTION
Adds a cookieHelper module for reading our FTkmt session cookie.
Checks the licence in the url is in the current FTkmt session cookie list.

Further work could be done on this to revalidate the admin user and refresh the FTkmt session if if the licence is not in the session list.  

Not sure if this can be completed for Monday so may need to be done as part of refactoring isAdminUser.
