### PR TITLE
remove httpOnly option from FTKmt cookie

### DIFF
--- a/lib/initCookieSession.js
+++ b/lib/initCookieSession.js
@@ -4,9 +4,7 @@ const config = require('./config');
 const sessionDetails = {
 	name: 'FTkmt',
 		keys: [config.get('KMT_SECRET')],
-		domain: config.get('DOMAIN'),
-		httpOnly: false,
-		secureProxy: true
+		domain: config.get('DOMAIN')
 };
 
 module.exports = cookieSession(sessionDetails);


### PR DESCRIPTION
Fixing the FTKmt cookie issue by removing the httpOnly option