### PR TITLE
Fix/error page

### DIFF
--- a/lib/middleware/errors.js
+++ b/lib/middleware/errors.js
@@ -46,27 +46,13 @@ function onUncaughtException(error) {
 
 function renderView(err, req, res, next) {
   const statusCode = err.status || 500;
-  const errorMessages = getErrorMessage(statusCode);
 
   const data = {
-    DEV_ADD_LIVERELOAD: config.DEV_ADD_LIVERELOAD,
-    LIVERELOAD_PORT: config.LIVERELOAD_PORT,
-    BASE_PATH_URL: config.BASE_PATH_URL,
-    BASE_PATH_ROUTE: config.BASE_PATH_ROUTE,
-    FEEDBACK_ROUTE: config.FEEDBACK_ROUTE,
-    FOOTER_THEME: config.FOOTER_THEME,
-    FOOTER_TYPE: config.FOOTER_TYPE,
-    FOOTER_PADDING_TOP : config.FOOTER_PADDING_TOP,
-    FOOTER_HELP_LINK : config.FOOTER_HELP_LINK,
-    KMT_CONFIG: '{}',
-    errorDetails: JSON.stringify({
-      messages: errorMessages,
-      code: statusCode
-    })
+    errorPageUrl: `${config.KAT_ERROR_PATH}/${statusCode}`
   };
 
   res.set({ 'Cache-Control': 'max-age=300, stale-while-revalidate=86400, stale-if-error=259200, public' });
-  res.status(statusCode).render('index', data);
+  res.status(statusCode).render('error', data);
 }
 
 module.exports = {

--- a/lib/middleware/errors.js
+++ b/lib/middleware/errors.js
@@ -1,7 +1,6 @@
 const logger = require('../logger');
 const uriConstructor = require('../uriConstructor');
 const config = require('../config');
-const getErrorMessage = require('../helpers/getErrorMessage');
 
 function canWithstand(error) {
   switch (error.code) {


### PR DESCRIPTION
Simply copying error functionality over to other apps is going to be a lengthy process. These changes will enable us to use a more "next-like" approach of serving the error page inside an `iframe`.