### PR TITLE
Error middleware signature

### DIFF
--- a/lib/middleware/errors.js
+++ b/lib/middleware/errors.js
@@ -22,7 +22,7 @@ function _applicationError (err, req, res, next) {
   next(err);
 }
 
-function _authenticationError (err, req, res) {
+function _authenticationError (err, req, res, next) {
   logger.log('warn', {'Unauthorized': 'Invalid user credentials'});
   logger.log('warn', {'Error stack': err.stack});
 
@@ -49,7 +49,7 @@ function onUncaughtException (error) {
   setImmediate(process.exit.bind(null, 66), 1000);// eslint-disable-line no-undef
 }
 
-function renderView (err, req, res) {
+function renderView (err, req, res, next) {
   const statusCode = err.status || 500;
 
   const data = {


### PR DESCRIPTION
Ensure the error middleware has the correct function signature.

I have been finding locally that the error page wasn't being rendered, that was because the middleware signature didn't match what's needed to handle errors in express.

Not sure at all why this is not an issue in production...