### PR TITLE
Don't cache default licence redirects

### DIFF
--- a/lib/middleware/redirectDefaultLicence.js
+++ b/lib/middleware/redirectDefaultLicence.js
@@ -13,7 +13,7 @@ module.exports = (req, res, next) => {
 				logger.info({operation, licenceId: licenceId, msg: `redirecting to ${licenceId}`});
 
 				// We don't want Fastly caching these per-user redirects.
-				res.set('Cache-Control', 'no-cache');
+				res.set('Cache-Control', 'private');
 
 				return res.redirect(`${process.env.KAT_BASE_PATH_URL || process.env.BASE_PATH_URL}${process.env.BASE_PATH_ROUTE}${licenceId}`);
 			}

--- a/lib/middleware/redirectDefaultLicence.js
+++ b/lib/middleware/redirectDefaultLicence.js
@@ -12,6 +12,9 @@ module.exports = (req, res, next) => {
 				const licenceId = req.listOfLicences[0].licenceId;
 				logger.info({operation, licenceId: licenceId, msg: `redirecting to ${licenceId}`});
 
+				// We don't want Fastly caching these per-user redirects.
+				res.set('Cache-Control', 'no-cache');
+
 				return res.redirect(`${process.env.KAT_BASE_PATH_URL || process.env.BASE_PATH_URL}${process.env.BASE_PATH_ROUTE}${licenceId}`);
 			}
 


### PR DESCRIPTION
I've noticed if I visit https://kat.ft.com, or any of the individual apps without specifying a licence I often get redirected to the wrong place.

From what I can tell the redirect responses are being cached by Fastly.

This _should_ ensure Fastly always checks the origin for this request according to https://docs.fastly.com/guides/tutorials/cache-control-tutorial#do-not-cache.