### PR TITLE
Maintenance flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test/config.json
 
 .idea
 *.env*
+
+package-lock.json

--- a/lib/middleware/checkMaintenanceStatus.js
+++ b/lib/middleware/checkMaintenanceStatus.js
@@ -1,0 +1,11 @@
+const logger = require('../logger');
+
+module.exports = (req, res, next) => {
+    logger.info({operation: 'checkMaintenanceStatus'});
+
+    if (res.locals.flags.katMaintenance) {
+      res.send(503); //503 status is the one we set Maintenance Page for in Fastly
+    } else {
+      next();
+    }
+};

--- a/lib/middleware/middlewareCombos.js
+++ b/lib/middleware/middlewareCombos.js
@@ -1,10 +1,12 @@
 module.exports = {
     defaultRoute: [
+        require('./checkMaintenanceStatus'),
         require('./verifySession').getUserId,
         require('./getLicenceList'),
         require('./redirectDefaultLicence')
     ],
     mainRoute: [
+        require('./checkMaintenanceStatus'),
         require('./verifySession').getUserId,
         require('./getLicenceId'),
         require('./checkLicenceStatus').isActive,


### PR DESCRIPTION
Added "checkMaintenanceStatus" function to default route and main route of middleware, that in case of katMaintenance flag being on, sends 503 status.