### PR TITLE
Update to the latest `kat-client-proxies` release

### DIFF
--- a/lib/middleware/checkLicenceStatus.js
+++ b/lib/middleware/checkLicenceStatus.js
@@ -57,7 +57,7 @@ function getLicenceDisplayInfo (req, res, next) {
 
 	return acquisitionCtxClient.getContexts({'access-licence-id': req.licenceId})
 		.then(licenceAcsDetails => {
-			const licenceName = licenceAcsDetails[0] && licenceAcsDetails[0].name ? licenceAcsDetails[0].name : '-';
+			const licenceName = licenceAcsDetails && licenceAcsDetails.name ? licenceAcsDetails.name : '-';
 			logger.info({operation, licenceId: req.licenceId, licenceName});
 			next();
 		})

--- a/lib/middleware/getListOfLicences.js
+++ b/lib/middleware/getListOfLicences.js
@@ -25,9 +25,8 @@ module.exports = (req) => {
 							promises.push(
 								acquisitionCtxClient.getContexts({'access-licence-id': item.licenceId})
 									.catch (() => [])
-									.then (info => {
+									.then (infoItem => {
 										item.name = '-';
-										const infoItem = info[0];
 										if (infoItem) {
 											item.name = infoItem.name || infoItem.displayName;
 										}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cookies": "~0.6.1",
     "bluebird": "~3.4.6",
     "body-parser": "~1.14.2",
-    "kat-client-proxies": "financial-times/kat-client-proxies#v2.1.10"
+    "kat-client-proxies": "financial-times/kat-client-proxies#v2.1.11"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.8.17",


### PR DESCRIPTION
As structure of the API endpoint result changed from https://acq-context-svc-gw-eu-west-1-prod.memb.ft.com to api.ft.com some adjustments were required to functions using acquisitionCtxClient (`checkLicenceStatus.js` and `getListOfLicences`). All tests still pass.