### PR TITLE
bump kat-client-proxies version to pick up 2fa changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "thurston.tye@ft.com",
   "license": "MIT",
   "dependencies": {
-    "@financial-times/kat-client-proxies": "^2.2.1",
+    "@financial-times/kat-client-proxies": "^3.0.0",
     "@financial-times/n-logger": "~5.4.0",
     "cookie-session": "~2.0.0-alpha.1",
     "cookies": "~0.6.1",


### PR DESCRIPTION
 🐿 v2.7.0

 v3.0.0 of `kat-client-proxies` removes hui which isn't used by `kmt-utilities`, so that major version isn't a breaking change for `kmt-utilities`. v3.0.1 introduces 2FA behind a flag so am bumping it here so that it gets picked up.