### PR TITLE
add gzip compression by default

### DIFF
--- a/lib/middleware/middlewareCombos.js
+++ b/lib/middleware/middlewareCombos.js
@@ -1,5 +1,8 @@
+const compression = require('compression');
+
 module.exports = {
 	defaultRoute: [
+		compression(),
 		require('./noCache'),
 		require('./checkMaintenanceStatus'),
 		require('./verifySession').getUserId,
@@ -7,6 +10,7 @@ module.exports = {
 		require('./redirectDefaultLicence')
 	],
 	mainRoute: [
+		compression(),
 		require('./noCache'),
 		require('./checkMaintenanceStatus'),
 		require('./verifySession').getUserId,

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   "dependencies": {
     "@financial-times/kat-client-proxies": "^4.0.0",
     "@financial-times/n-logger": "~5.4.0",
-    "cookie-session": "~2.0.0-alpha.1",
-    "cookies": "~0.6.1",
     "bluebird": "~3.4.6",
-    "body-parser": "~1.14.2"
+    "body-parser": "~1.14.2",
+    "compression": "^1.7.2",
+    "cookie-session": "~2.0.0-alpha.1",
+    "cookies": "~0.6.1"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.8.17",


### PR DESCRIPTION
Adds gzip compression middleware by default on the `defaultRoute` and `mainRoute` middleware combos.

 🐿 v2.7.0