### PR TITLE
Make middleware KAT API friendly

### DIFF
--- a/lib/middleware/getAuthToken.js
+++ b/lib/middleware/getAuthToken.js
@@ -5,7 +5,8 @@ const sessionClient = require('@financial-times/kat-client-proxies').sessionClie
 
 module.exports = (req, res, next) => {
 	const operation = 'getAuthToken';
-	logger.info({operation, licenceId: req.params.licenceId, ignoreAuth: config.IGNORE_AUTH_TOKEN});
+	const licenceId = req.params.licenceId || req.licenceId;
+	logger.info({operation, licenceId, ignoreAuth: config.IGNORE_AUTH_TOKEN});
 
 	if (!!req.apiAuthToken) {
 		return Promise.resolve(next());
@@ -20,7 +21,7 @@ module.exports = (req, res, next) => {
 
 	return sessionClient.getAuthToken(FTSessionSecure)
 		.then(apiAuthToken => {
-			logger.info({operation, result: 'success', licenceId: req.params.licenceId});
+			logger.info({operation, result: 'success', licenceId});
 
 			req.apiAuthToken = apiAuthToken;
 			next();

--- a/lib/middleware/isAdminSession.js
+++ b/lib/middleware/isAdminSession.js
@@ -51,18 +51,9 @@ function isAdminUser (req, res, next) {
 							throw err;
 						}
 
-						let adminUser = 'unnamed';
-						adminUserList.every(item => {
-							if (item.id === currentUser) {
-								adminUser = item.email;
-								return false;
-							}
-							return true;
-						});
-
 						//set KAT session
 						if (req.session) {
-							req.session.kmtLoggedIn = {displayName: adminUser, userId: currentUser};
+							req.session.kmtLoggedIn = {userId: currentUser};
 						}
 
 						return req.listOfLicences;

--- a/lib/middleware/isAdminSession.js
+++ b/lib/middleware/isAdminSession.js
@@ -61,7 +61,9 @@ function isAdminUser (req, res, next) {
 						});
 
 						//set KAT session
-						req.session.kmtLoggedIn = {displayName: adminUser, userId: currentUser};
+						if (req.session) {
+							req.session.kmtLoggedIn = {displayName: adminUser, userId: currentUser};
+						}
 
 						return req.listOfLicences;
 					});
@@ -73,7 +75,9 @@ function isAdminUser (req, res, next) {
 		})
 		.then(licenceListSort)
 		.then(licenceList => {
-			req.KATConfig = setKATConfig(req, licenceList);
+			if (req.session) {
+				req.KATConfig = setKATConfig(req, licenceList);
+			}
 			next();
 		})
 		.catch(next);

--- a/lib/middleware/verifySession.js
+++ b/lib/middleware/verifySession.js
@@ -5,18 +5,18 @@ const cookieHandler = require('./../helpers/cookieHandler');
 const sessionClient = require('@financial-times/kat-client-proxies').sessionClient;
 
 function getUserId (req, res, next) {
-
 	const operation = 'verifySession.getUserId';
-	logger.info({operation, licenceId: req.params.licenceId});
+	const licenceId = req.params.licenceId || req.licenceId;
+	logger.info({operation, licenceId});
 
 	// if the session token exists => verify it
 	const secureSessionToken = cookieHandler.get(req, res, 'FTSession_s');
 
 	if (!!secureSessionToken) {
-		logger.info({operation, licenceId: req.params.licenceId, msg: 'verify the session token'});
+		logger.info({operation, licenceId, msg: 'verify the session token'});
 		return sessionClient.verify(secureSessionToken)
 			.then(result => {
-				logger.info({ operation, licenceId: req.params.licenceId, msg: 'session valid' });
+				logger.info({ operation, licenceId, msg: 'session valid' });
 				req.currentUser = result;
 				next();
 			})

--- a/test/lib/middleware/isAdminSession.spec.js
+++ b/test/lib/middleware/isAdminSession.spec.js
@@ -153,7 +153,7 @@ describe('middleware/isAdminSession', () => {
 
 					const katConfig = req.KATConfig;
 					expect(katConfig).to.be.an('object');
-					expectOwnProperties(katConfig, ['licenceList', 'displayName', 'userId']);
+					expectOwnProperties(katConfig, ['licenceList', 'userId']);
 					expect(katConfig.userId).to.equal(uuids.validUser);
 
 					const licenceList = katConfig.licenceList;


### PR DESCRIPTION
Some of the middleware works great for some of our Front-End apps, but not so much when used in `kat-api`.

This adds some conditions around logging and working with the cookie session to make it more friendly for the KAT API.