### PR TITLE
Log application errors to Sentry using n-raven

### DIFF
--- a/lib/middleware/errors.js
+++ b/lib/middleware/errors.js
@@ -3,6 +3,7 @@
 const logger = require('../logger');
 const uriConstructor = require('../uriConstructor');
 const config = require('../config');
+const nRaven = require('@financial-times/n-raven');
 
 function canWithstand (error) {
 	switch (error.code) {
@@ -19,6 +20,8 @@ function _applicationError (err, req, res, next) {
 
 	logger.log('error', {'Application error': err.message});
 	logger.log('error', {'Error stack': err.stack});
+
+	nRaven.captureError(err);
 
 	next(err);
 }
@@ -47,6 +50,7 @@ function onUncaughtException (error) {
 		return;
 	}
 	logger.log('error', {'Uncaught exception':'process will exit', error:error});
+	nRaven.captureError(error);
 	setImmediate(process.exit.bind(null, 66), 1000);// eslint-disable-line no-undef
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@financial-times/kat-client-proxies": "^4.0.2",
     "@financial-times/n-logger": "~5.4.0",
+    "@financial-times/n-raven": "^3.0.4",
     "bluebird": "~3.4.6",
     "body-parser": "~1.14.2",
     "compression": "^1.7.2",


### PR DESCRIPTION
Because the KAT applications render their own error pages, it never makes it to the error middleware defined in n-express (which puts errors in sentry).

This change will log application errors to sentry (not authentication errors - not sure if they should?)
