### PR TITLE
catch session client errors and redirect to logout

### DIFF
--- a/lib/middleware/verifySession.js
+++ b/lib/middleware/verifySession.js
@@ -20,7 +20,12 @@ function getUserId (req, res, next) {
 				req.currentUser = result;
 				next();
 			})
-			.catch(next);
+			.catch(error => {
+				logger.error({operation, msg: 'Error Verifying Session'}, error);
+				res.set('Cache-Control', res.FT_NO_CACHE);
+				res.set('Surrogate-Control', res.FT_NO_CACHE);
+				res.redirect(`${config.LOGOUT_URL}?location=${encodeURIComponent(`https://${req.hostname}${req.originalUrl}`)}`);
+			});
 	}
 
 	logger.info({operation, redirect: 'to accounts.ft.com/login', reason: 'no FTSession found, so bye-bye'});


### PR DESCRIPTION
So, I managed to reproduce getting 500s at kat.ft.com/overview. The logs in heroku, said that the session client had 404'd.

Making the same request in Postman gave me a 404 with the body `{ "sessionInvalidReason": "REVOKED" }`. In [`kat-client-proxies`](https://github.com/Financial-Times/kat-client-proxies/blob/master/lib/sessionClient.js#L23) the response was throwing which was never being handled and must be falling through to the error middleware. 

This change catches any errors and redirects the use to `/logout` which should clear any session tokens the user has.


 🐿 v2.9.0