### PR TITLE
Logs empty array

### DIFF
--- a/lib/middleware/getListOfLicences.js
+++ b/lib/middleware/getListOfLicences.js
@@ -17,9 +17,9 @@ module.exports = (req) => {
 
 	return accessLicenceClient.getLicences({adminuserid: req.currentUser.uuid})
 		.then(licences => {
-			if (!Array.isArray(licences)) {
+			if (!Array.isArray(licences) || !licences.length) {
 				const error = new Error('Invalid licence response.');
-				logger.error({ operation, msg: error.message }, error);
+				logger.error({ operation, msg: error.message }, error, licences);
 				throw error;
 			}
 

--- a/lib/middleware/getListOfLicences.js
+++ b/lib/middleware/getListOfLicences.js
@@ -19,7 +19,7 @@ module.exports = (req) => {
 		.then(licences => {
 			if (!Array.isArray(licences) || !licences.length) {
 				const error = new Error('Invalid licence response.');
-				logger.error({ operation, msg: error.message }, error, licences);
+				logger.error({ operation, action: 'getLicence', msg: error.message, licences }, error);
 				throw error;
 			}
 

--- a/lib/middleware/redirectDefaultLicence.js
+++ b/lib/middleware/redirectDefaultLicence.js
@@ -21,7 +21,7 @@ module.exports = (req, res, next) => {
 			throw new Error('No list of licences found');
 		})
 		.catch(err => {
-			logger.info({operation, err});
+			logger.error({operation, err});
 
 			const userErr = new Error('You need to have a valid license identifier to use this tool.');
 			userErr.status = 404;


### PR DESCRIPTION
When calling the endpoint `/licences?adminuserid={userId}` it will return a status of 200 and an empty array when a user is not an admin user of a license, therefore, we need to throw and log the error.  

We believe there may be an issue with membership Apis picking up admin users from salesforce and, therefore, this log should help us to determine whether this is true.