### PR TITLE
Fix logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const nextLogger = require('@financial-times/n-logger').default;
-const logger = nextLogger.logger;
+const logger = require('@financial-times/n-logger').default;
 
 module.exports = logger;


### PR DESCRIPTION
As mentioned here: https://github.com/Financial-Times/next-eventpromo-api/pull/60

> This was using a different logger object, which did not have any of the extra transports attached.

🐿 v2.10.3